### PR TITLE
Add simple Laser Tag birthday game

### DIFF
--- a/packages/laser-tag-game/index.js
+++ b/packages/laser-tag-game/index.js
@@ -1,0 +1,34 @@
+const readline = require('node:readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const allowedNames = ['Samuel', 'Lennard', 'Filip'];
+
+rl.question('Podaj swoje imie: ', (name) => {
+  if (!allowedNames.includes(name.trim())) {
+    console.log('Nie zostales zaproszony do gry, twoj telefon wybuchnie za 10 sekund!');
+    let count = 10;
+    const countdown = setInterval(() => {
+      if (count === 0) {
+        clearInterval(countdown);
+        console.log('BAM!');
+        rl.close();
+      } else {
+        console.log(count);
+        count -= 1;
+      }
+    }, 1000);
+    return;
+  }
+
+  console.log(`Czesc ${name}! Witaj w Laser Tag!`);
+  console.log('Gra zaraz sie rozpocznie...');
+
+  setTimeout(() => {
+    console.log('zapraszam cie na urodziny');
+    rl.close();
+  }, 2 * 60 * 1000);
+});

--- a/packages/laser-tag-game/package.json
+++ b/packages/laser-tag-game/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "laser-tag-game",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}


### PR DESCRIPTION
## Summary
- create `laser-tag-game` package with a small Node.js script
- script checks for approved names and runs a short countdown game

## Testing
- `npx prettier -w packages/laser-tag-game/index.js packages/laser-tag-game/package.json`

------
https://chatgpt.com/codex/tasks/task_e_683ff47c9c50832299ce4116e28dc8b7