### PR TITLE
feat: add voice transcription mailer example

### DIFF
--- a/packages/voice-mailer/.env.example
+++ b/packages/voice-mailer/.env.example
@@ -1,0 +1,15 @@
+# Klucz API OpenAI używany do transkrypcji nagrań
+OPENAI_API_KEY=
+
+# Konfiguracja serwera SMTP używanego do wysyłki e-maili
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+
+# Adres nadawcy i odbiorcy wiadomości
+SENDER_EMAIL=
+TARGET_EMAIL=
+
+# Port HTTP, na którym ma działać aplikacja (opcjonalny)
+PORT=3000

--- a/packages/voice-mailer/README.md
+++ b/packages/voice-mailer/README.md
@@ -1,0 +1,51 @@
+# Voice Mailer
+
+Prosty serwer Express z interfejsem WWW, który pozwala nagrać krótką wiadomość głosową, zamienić ją na tekst przy pomocy OpenAI Whisper i wysłać transkrypt na skonfigurowany adres e-mail.
+
+## Wymagania
+
+- Node.js 18 lub nowszy
+- Konto OpenAI z kluczem API
+- Dane dostępowe do serwera SMTP
+
+## Konfiguracja
+
+1. Sklonuj repozytorium i przejdź do katalogu projektu `packages/voice-mailer`.
+2. Utwórz plik `.env` na podstawie `.env.example`:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Uzupełnij wartości zmiennych środowiskowych:
+
+   - `OPENAI_API_KEY` – klucz API OpenAI
+   - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` – dane logowania do SMTP
+   - `SENDER_EMAIL` – adres nadawcy
+   - `TARGET_EMAIL` – docelowy adres, na który zostanie wysłany transkrypt
+
+4. Zainstaluj zależności i uruchom serwer:
+
+   ```bash
+   pnpm install
+   pnpm --filter @n8n/voice-mailer dev
+   ```
+
+   Domyślnie aplikacja wystartuje pod adresem [http://localhost:3000](http://localhost:3000).
+
+## Użytkowanie
+
+1. Otwórz stronę w przeglądarce z dostępem do mikrofonu.
+2. Kliknij duży czerwony przycisk z ikoną mikrofonu, aby rozpocząć nagrywanie. Kliknij ponownie, aby zakończyć.
+3. Po zakończeniu nagrania wciśnij przycisk **"Transkrybuj i wyślij"**. Aplikacja prześle plik do serwera, który wykona transkrypcję i wyśle treść na skonfigurowany e-mail.
+4. Transkrypt zostanie także wyświetlony na stronie.
+
+## Uwagi dotyczące prywatności
+
+- Nagranie audio jest przesyłane do OpenAI wyłącznie w celu wykonania transkrypcji.
+- Po przetworzeniu plik tymczasowy z nagraniem jest usuwany z serwera.
+- Wysyłka e-maila odbywa się przez skonfigurowany serwer SMTP.
+
+## Licencja
+
+Projekt dziedziczy licencję repozytorium nadrzędnego.

--- a/packages/voice-mailer/package.json
+++ b/packages/voice-mailer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@n8n/voice-mailer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "nodemailer": "^6.9.13",
+    "openai": "^4.55.4"
+  }
+}

--- a/packages/voice-mailer/public/app.js
+++ b/packages/voice-mailer/public/app.js
@@ -1,0 +1,119 @@
+const recordButton = document.getElementById('recordButton');
+const transcribeButton = document.getElementById('transcribeButton');
+const statusElement = document.getElementById('status');
+const transcriptElement = document.getElementById('transcript');
+
+let mediaRecorder;
+let recordedChunks = [];
+let recordedBlob = null;
+let mediaStream;
+
+const uiState = {
+	recording: false,
+	transcribing: false,
+	hasRecording: false,
+};
+
+recordButton.addEventListener('click', async () => {
+	if (mediaRecorder && mediaRecorder.state === 'recording') {
+		stopRecording();
+		return;
+	}
+
+	try {
+		await startRecording();
+	} catch (error) {
+		console.error('Nie udało się rozpocząć nagrywania', error);
+		statusElement.textContent = 'Nie udało się uzyskać dostępu do mikrofonu.';
+	}
+});
+
+transcribeButton.addEventListener('click', async () => {
+	if (!recordedBlob) {
+		statusElement.textContent = 'Najpierw nagraj wiadomość.';
+		return;
+	}
+
+	const formData = new FormData();
+	formData.append('audio', recordedBlob, 'recording.webm');
+
+	setButtonsState({ transcribing: true });
+	statusElement.textContent = 'Przetwarzanie nagrania…';
+
+	try {
+		const response = await fetch('/api/transcribe', {
+			method: 'POST',
+			body: formData,
+		});
+
+		if (!response.ok) {
+			const errorPayload = await response.json().catch(() => ({}));
+			throw new Error(errorPayload.error || 'Serwer zwrócił błąd.');
+		}
+
+		const data = await response.json();
+		transcriptElement.textContent = data.transcript;
+		transcriptElement.focus();
+		statusElement.textContent = 'Transkrypt wysłany na e-mail.';
+	} catch (error) {
+		console.error('Błąd podczas transkrypcji', error);
+		statusElement.textContent = error.message || 'Nie udało się przetworzyć nagrania.';
+	} finally {
+		setButtonsState({ transcribing: false, hasRecording: Boolean(recordedBlob) });
+	}
+});
+
+async function startRecording() {
+	if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+		throw new Error('Twoja przeglądarka nie obsługuje nagrywania audio.');
+	}
+
+	statusElement.textContent = 'Proszę zezwolić na dostęp do mikrofonu…';
+
+	if (!mediaStream) {
+		mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+	}
+
+	mediaRecorder = new MediaRecorder(mediaStream);
+	recordedChunks = [];
+	recordedBlob = null;
+
+	mediaRecorder.addEventListener('dataavailable', (event) => {
+		if (event.data.size > 0) {
+			recordedChunks.push(event.data);
+		}
+	});
+
+	mediaRecorder.addEventListener('stop', () => {
+		recordedBlob = new Blob(recordedChunks, { type: 'audio/webm' });
+		setButtonsState({ recording: false, hasRecording: recordedBlob.size > 0 });
+		if (recordedBlob.size > 0) {
+			statusElement.textContent = 'Nagranie zakończone. Możesz wysłać transkrypt.';
+		} else {
+			statusElement.textContent = 'Nagranie jest puste. Spróbuj ponownie.';
+		}
+	});
+
+	mediaRecorder.start();
+	setButtonsState({ recording: true, hasRecording: false });
+	statusElement.textContent = 'Nagrywanie w toku… kliknij ponownie, aby zakończyć.';
+}
+
+function stopRecording() {
+	if (mediaRecorder && mediaRecorder.state === 'recording') {
+		mediaRecorder.stop();
+	}
+}
+
+function setButtonsState(partialState = {}) {
+	Object.assign(uiState, partialState);
+
+	recordButton.classList.toggle('recording', uiState.recording);
+	recordButton.setAttribute('aria-pressed', uiState.recording ? 'true' : 'false');
+	recordButton.querySelector('.label').textContent = uiState.recording
+		? 'Zatrzymaj nagrywanie'
+		: 'Rozpocznij nagrywanie';
+
+	recordButton.disabled = uiState.transcribing;
+	transcribeButton.disabled = uiState.recording || uiState.transcribing || !uiState.hasRecording;
+}

--- a/packages/voice-mailer/public/index.html
+++ b/packages/voice-mailer/public/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Voice Mailer</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Voice Mailer</h1>
+      <p>Nagraj wiadomość głosową i wyślij jej transkrypt na e-mail.</p>
+
+      <div class="buttons">
+        <button id="recordButton" class="record-button" aria-pressed="false">
+          <span class="icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 15a3 3 0 0 0 3-3V6a3 3 0 1 0-6 0v6a3 3 0 0 0 3 3zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 14 0h-2zm-5 8a1 1 0 0 0 1-1v-2h-2v2a1 1 0 0 0 1 1z" />
+            </svg>
+          </span>
+          <span class="label">Rozpocznij nagrywanie</span>
+        </button>
+
+        <button id="transcribeButton" class="transcribe-button" disabled>
+          Transkrybuj i wyślij
+        </button>
+      </div>
+
+      <div id="status" class="status" role="status" aria-live="polite"></div>
+      <section class="transcript" aria-live="polite">
+        <h2>Ostatni transkrypt</h2>
+        <pre id="transcript" tabindex="0"></pre>
+      </section>
+    </main>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/packages/voice-mailer/public/styles.css
+++ b/packages/voice-mailer/public/styles.css
@@ -1,0 +1,172 @@
+:root {
+	color-scheme: light dark;
+	font-family:
+		'Inter',
+		system-ui,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		sans-serif;
+	line-height: 1.5;
+	background: radial-gradient(circle at top, #2b2d42 0%, #1a1b2e 45%, #0f101a 100%);
+	min-height: 100vh;
+	margin: 0;
+	color: #f9f9ff;
+}
+
+body {
+	margin: 0;
+}
+
+.container {
+	max-width: 640px;
+	margin: 0 auto;
+	padding: 4rem 1.5rem 3rem;
+	text-align: center;
+}
+
+h1 {
+	font-size: clamp(2.2rem, 4vw, 3rem);
+	margin-bottom: 0.25rem;
+}
+
+p {
+	margin-top: 0;
+	margin-bottom: 2rem;
+	color: rgba(249, 249, 255, 0.8);
+}
+
+.buttons {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	align-items: center;
+	justify-content: center;
+	margin-bottom: 2.5rem;
+}
+
+.record-button {
+	position: relative;
+	width: clamp(180px, 22vw, 240px);
+	aspect-ratio: 1 / 1;
+	border-radius: 999px;
+	border: none;
+	background: radial-gradient(circle at 30% 30%, #ff6b6b 0%, #c9184a 70%, #a4133c 100%);
+	box-shadow: 0 20px 40px rgba(201, 24, 74, 0.45);
+	color: #fff;
+	cursor: pointer;
+	display: grid;
+	place-items: center;
+	transition:
+		transform 0.2s ease,
+		box-shadow 0.2s ease,
+		filter 0.2s ease;
+}
+
+.record-button .icon {
+	display: block;
+	width: 64px;
+	height: 64px;
+}
+
+.record-button .icon svg {
+	width: 100%;
+	height: 100%;
+	fill: currentColor;
+}
+
+.record-button .label {
+	position: absolute;
+	bottom: -3.5rem;
+	left: 50%;
+	transform: translateX(-50%);
+	font-size: 1rem;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	font-weight: 600;
+}
+
+.record-button:focus-visible {
+	outline: 3px solid rgba(255, 255, 255, 0.8);
+	outline-offset: 6px;
+}
+
+.record-button.recording {
+	transform: scale(0.94);
+	filter: saturate(1.25);
+	box-shadow: 0 10px 25px rgba(164, 19, 60, 0.6);
+}
+
+.transcribe-button {
+	padding: 0.85rem 2.75rem;
+	border-radius: 999px;
+	border: none;
+	background: linear-gradient(135deg, #4facfe 0%, #38f9d7 100%);
+	color: #101220;
+	font-size: 1rem;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	cursor: pointer;
+	transition:
+		transform 0.2s ease,
+		box-shadow 0.2s ease;
+	box-shadow: 0 12px 20px rgba(79, 172, 254, 0.35);
+}
+
+.transcribe-button:disabled {
+	cursor: not-allowed;
+	opacity: 0.45;
+	box-shadow: none;
+}
+
+.transcribe-button:not(:disabled):hover {
+	transform: translateY(-2px);
+	box-shadow: 0 16px 30px rgba(56, 249, 215, 0.4);
+}
+
+.transcribe-button:focus-visible {
+	outline: 3px solid rgba(255, 255, 255, 0.75);
+	outline-offset: 4px;
+}
+
+.status {
+	min-height: 1.5rem;
+	font-size: 0.95rem;
+	color: rgba(249, 249, 255, 0.85);
+}
+
+.transcript {
+	background: rgba(16, 18, 32, 0.65);
+	backdrop-filter: blur(18px);
+	border-radius: 18px;
+	padding: 1.5rem;
+	text-align: left;
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.transcript h2 {
+	margin-top: 0;
+	font-size: 1.15rem;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	color: rgba(249, 249, 255, 0.7);
+}
+
+.transcript pre {
+	font-family: 'Fira Code', 'Courier New', Courier, monospace;
+	white-space: pre-wrap;
+	margin: 0;
+	font-size: 1rem;
+	color: rgba(249, 249, 255, 0.95);
+}
+
+@media (min-width: 720px) {
+	.buttons {
+		flex-direction: row;
+	}
+
+	.record-button .label {
+		bottom: -3rem;
+	}
+}

--- a/packages/voice-mailer/server.js
+++ b/packages/voice-mailer/server.js
@@ -1,0 +1,154 @@
+import express from 'express';
+import multer from 'multer';
+import dotenv from 'dotenv';
+import nodemailer from 'nodemailer';
+import OpenAI from 'openai';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+
+dotenv.config();
+
+const requiredEnvVars = [
+	'OPENAI_API_KEY',
+	'SMTP_HOST',
+	'SMTP_PORT',
+	'SMTP_USER',
+	'SMTP_PASS',
+	'SENDER_EMAIL',
+	'TARGET_EMAIL',
+];
+
+const missing = requiredEnvVars.filter((key) => !process.env[key]);
+if (missing.length > 0) {
+	console.warn(
+		`Ostrzeżenie: brakujące zmienne środowiskowe - ${missing.join(', ')}. ` +
+			'Serwer może nie działać prawidłowo, dopóki nie uzupełnisz konfiguracji.',
+	);
+}
+
+const openai = process.env.OPENAI_API_KEY
+	? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+	: null;
+
+const app = express();
+const upload = multer({
+	storage: multer.memoryStorage(),
+	limits: { fileSize: 25 * 1024 * 1024 },
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/api/transcribe', upload.single('audio'), async (req, res) => {
+	if (!req.file) {
+		return res.status(400).json({ error: 'Nie otrzymano żadnego nagrania.' });
+	}
+
+	if (!openai) {
+		return res.status(500).json({ error: 'Brak konfiguracji klienta OpenAI.' });
+	}
+
+	const tempFilePath = path.join(
+		os.tmpdir(),
+		`voice-mailer-${Date.now()}-${crypto.randomUUID()}.${getExtensionForMime(req.file.mimetype)}`,
+	);
+
+	try {
+		await fsPromises.writeFile(tempFilePath, req.file.buffer);
+
+		const transcriptionResponse = await openai.audio.transcriptions.create({
+			file: fs.createReadStream(tempFilePath),
+			model: 'gpt-4o-mini-transcribe',
+			response_format: 'text',
+			temperature: 0.2,
+		});
+
+		const transcriptText =
+			typeof transcriptionResponse === 'string'
+				? transcriptionResponse.trim()
+				: (transcriptionResponse.text || '').trim();
+
+		if (!transcriptText) {
+			return res.status(500).json({ error: 'Nie udało się uzyskać transkryptu.' });
+		}
+
+		try {
+			await sendEmail(transcriptText);
+		} catch (emailError) {
+			console.error('Błąd podczas wysyłania e-maila:', emailError);
+			return res
+				.status(500)
+				.json({ error: 'Transkrypcja się powiodła, ale nie udało się wysłać e-maila.' });
+		}
+
+		return res.json({ success: true, transcript: transcriptText });
+	} catch (error) {
+		console.error('Błąd podczas przetwarzania nagrania:', error);
+		return res.status(500).json({ error: 'Wystąpił problem z przetworzeniem nagrania.' });
+	} finally {
+		await safeUnlink(tempFilePath);
+	}
+});
+
+app.use((req, res, next) => {
+	if (req.method === 'GET' && req.accepts('html')) {
+		return res.sendFile(path.join(__dirname, 'public', 'index.html'));
+	}
+	return next();
+});
+
+const port = Number.parseInt(process.env.PORT || '3000', 10);
+app.listen(port, () => {
+	console.log(`Voice Mailer nasłuchuje na http://localhost:${port}`);
+});
+
+function getExtensionForMime(mimeType) {
+	switch (mimeType) {
+		case 'audio/webm':
+			return 'webm';
+		case 'audio/mp4':
+			return 'm4a';
+		case 'audio/mpeg':
+			return 'mp3';
+		case 'audio/wav':
+		case 'audio/x-wav':
+			return 'wav';
+		default:
+			return 'dat';
+	}
+}
+
+async function safeUnlink(filePath) {
+	try {
+		await fsPromises.unlink(filePath);
+	} catch (error) {
+		if (error && error.code !== 'ENOENT') {
+			console.warn('Nie udało się usunąć pliku tymczasowego:', error);
+		}
+	}
+}
+
+async function sendEmail(message) {
+	const transporter = nodemailer.createTransport({
+		host: process.env.SMTP_HOST,
+		port: Number.parseInt(process.env.SMTP_PORT || '587', 10),
+		secure: Number.parseInt(process.env.SMTP_PORT || '587', 10) === 465,
+		auth: {
+			user: process.env.SMTP_USER,
+			pass: process.env.SMTP_PASS,
+		},
+	});
+
+	await transporter.sendMail({
+		from: process.env.SENDER_EMAIL,
+		to: process.env.TARGET_EMAIL,
+		subject: 'Nowa transkrypcja wiadomości głosowej',
+		text: message,
+	});
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2428,6 +2428,24 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/voice-mailer:
+    dependencies:
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
+      multer:
+        specifier: ^1.4.5-lts.1
+        version: 1.4.5-lts.1
+      nodemailer:
+        specifier: ^6.9.13
+        version: 6.10.1
+      openai:
+        specifier: ^4.55.4
+        version: 4.78.1(encoding@0.1.13)(zod@3.24.1)
+
   packages/workflow:
     dependencies:
       '@n8n/tournament':
@@ -6843,6 +6861,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -7034,6 +7056,9 @@ packages:
   array-buffer-byte-length@1.0.1:
     resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
     engines: {node: '>= 0.4'}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-hyper-unique@2.1.4:
     resolution: {integrity: sha512-RVsGx2YpFGhGpgdkK7A0VjFQecVUCowpkQerGCsyXVRXHxccAlPPTDt9ueF/X7Zq/6z6duZ49i9WzTCzcnQygQ==}
@@ -7286,6 +7311,10 @@ packages:
 
   bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
+
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
@@ -7767,6 +7796,10 @@ packages:
   constantinople@4.0.1:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
     engines: {node: '>= 0.6'}
@@ -7795,6 +7828,10 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
+
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -8162,6 +8199,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-libc@2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
@@ -8260,10 +8301,6 @@ packages:
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
-  dotenv@16.3.1:
-    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
-    engines: {node: '>=12'}
-
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
@@ -8338,6 +8375,10 @@ packages:
 
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -8764,6 +8805,10 @@ packages:
     peerDependencies:
       express: ^4.11 || 5 || ^5.0.0-beta.1
 
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
@@ -8892,6 +8937,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
@@ -8993,6 +9042,10 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -10603,6 +10656,9 @@ packages:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -10637,6 +10693,11 @@ packages:
   mime-types@3.0.1:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -10963,6 +11024,7 @@ packages:
   multer@1.4.5-lts.1:
     resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==}
     engines: {node: '>= 6.0.0'}
+    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -11112,6 +11174,10 @@ packages:
   node-ssh@13.2.0:
     resolution: {integrity: sha512-7vsKR2Bbs66th6IWCy/7SN4MSwlVt+G6QrHB631BjRUM8/LmvDugtYhi0uAmgvHS/+PVurfNBOmELf30rm0MZg==}
     engines: {node: '>= 10'}
+
+  nodemailer@6.10.1:
+    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+    engines: {node: '>=6.0.0'}
 
   nodemailer@6.9.9:
     resolution: {integrity: sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==}
@@ -11457,6 +11523,9 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
@@ -11943,6 +12012,10 @@ packages:
     resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
     engines: {node: '>=0.6'}
 
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+    engines: {node: '>=0.6'}
+
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -11973,6 +12046,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
 
   raw-body@3.0.0:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
@@ -12369,6 +12446,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
@@ -12381,6 +12462,10 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
@@ -12579,6 +12664,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
@@ -12824,10 +12910,12 @@ packages:
   superagent@9.0.2:
     resolution: {integrity: sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==}
     engines: {node: '>=14.18.0'}
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supertest@7.0.0:
     resolution: {integrity: sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==}
     engines: {node: '>=14.18.0'}
+    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -13502,6 +13590,10 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   uuencode@0.0.4:
     resolution: {integrity: sha512-yEEhCuCi5wRV7Z5ZVf9iV2gWMvUZqKJhAs1ecFdKJ0qzbyaVelmsE3QjYAamehfp9FKLiZbKldd+jklG3O0LfA==}
 
@@ -13683,6 +13775,9 @@ packages:
 
   vue-component-type-helpers@2.2.10:
     resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
+
+  vue-component-type-helpers@3.0.8:
+    resolution: {integrity: sha512-WyR30Eq15Y/+odrUUMax6FmPbZwAp/HnC7qgR1r3lVFAcqwQ4wUoV79Mbh4SxDy3NiqDa+G4TOKD5xXSgBHo5A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -18817,7 +18912,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.8.2)
-      vue-component-type-helpers: 2.2.10
+      vue-component-type-helpers: 3.0.8
 
   '@supabase/auth-js@2.65.0':
     dependencies:
@@ -19944,6 +20039,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
@@ -20137,6 +20237,8 @@ snapshots:
     dependencies:
       call-bind: 1.0.7
       is-array-buffer: 3.0.4
+
+  array-flatten@1.1.1: {}
 
   array-hyper-unique@2.1.4:
     dependencies:
@@ -20453,6 +20555,23 @@ snapshots:
   bn.js@4.12.0: {}
 
   bn.js@5.2.1: {}
+
+  body-parser@1.20.3:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.13.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.2.0:
     dependencies:
@@ -21011,6 +21130,10 @@ snapshots:
       '@babel/parser': 7.26.10
       '@babel/types': 7.26.10
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.0.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -21034,6 +21157,8 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie-signature@1.2.2: {}
+
+  cookie@0.7.1: {}
 
   cookie@0.7.2: {}
 
@@ -21437,6 +21562,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  destroy@1.2.0: {}
+
   detect-libc@2.0.1: {}
 
   detect-libc@2.0.3: {}
@@ -21530,8 +21657,6 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.6.2
 
-  dotenv@16.3.1: {}
-
   dotenv@16.4.5: {}
 
   dotenv@8.6.0: {}
@@ -21622,6 +21747,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   enabled@2.0.0: {}
+
+  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -21925,7 +22052,7 @@ snapshots:
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -21950,7 +22077,7 @@ snapshots:
 
   eslint-module-utils@2.8.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.8.2)
       eslint: 8.57.0
@@ -21970,7 +22097,7 @@ snapshots:
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -22264,6 +22391,42 @@ snapshots:
     dependencies:
       express: 5.1.0
 
+  express@4.21.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -22419,6 +22582,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.3.1:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@2.1.0:
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
@@ -22534,6 +22709,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@4.3.7: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -22789,7 +22966,7 @@ snapshots:
       array-parallel: 0.1.3
       array-series: 0.1.5
       cross-spawn: 7.0.6
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23161,7 +23338,7 @@ snapshots:
   infisical-node@1.3.0:
     dependencies:
       axios: 1.8.3
-      dotenv: 16.3.1
+      dotenv: 16.4.5
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
     transitivePeerDependencies:
@@ -23200,7 +23377,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
-      side-channel: 1.0.6
+      side-channel: 1.1.0
 
   interpret@1.4.0: {}
 
@@ -24448,7 +24625,7 @@ snapshots:
       minipass-fetch: 1.4.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
-      negotiator: 0.6.3
+      negotiator: 0.6.4
       promise-retry: 2.0.1
       socks-proxy-agent: 6.2.1
       ssri: 8.0.1
@@ -24530,6 +24707,8 @@ snapshots:
 
   meow@13.2.0: {}
 
+  merge-descriptors@1.0.3: {}
+
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
@@ -24554,6 +24733,8 @@ snapshots:
   mime-types@3.0.1:
     dependencies:
       mime-db: 1.54.0
+
+  mime@1.6.0: {}
 
   mime@2.6.0: {}
 
@@ -25133,8 +25314,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  negotiator@0.6.3:
-    optional: true
+  negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
 
@@ -25238,6 +25418,8 @@ snapshots:
       sb-scandir: 3.1.0
       shell-escape: 0.2.0
       ssh2: 1.15.0
+
+  nodemailer@6.10.1: {}
 
   nodemailer@6.9.9: {}
 
@@ -25632,6 +25814,8 @@ snapshots:
       lru-cache: 11.1.0
       minipass: 7.1.2
 
+  path-to-regexp@0.1.12: {}
+
   path-to-regexp@8.2.0: {}
 
   path-type@4.0.0: {}
@@ -25650,7 +25834,7 @@ snapshots:
 
   pdf-parse@1.1.1:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       node-ensure: 0.0.0
     transitivePeerDependencies:
       - supports-color
@@ -26119,7 +26303,7 @@ snapshots:
 
   qs@6.10.4:
     dependencies:
-      side-channel: 1.0.6
+      side-channel: 1.1.0
 
   qs@6.11.0:
     dependencies:
@@ -26128,6 +26312,10 @@ snapshots:
   qs@6.11.2:
     dependencies:
       side-channel: 1.0.4
+
+  qs@6.13.0:
+    dependencies:
+      side-channel: 1.1.0
 
   qs@6.14.0:
     dependencies:
@@ -26152,6 +26340,13 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  raw-body@2.5.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   raw-body@3.0.0:
     dependencies:
@@ -26489,7 +26684,7 @@ snapshots:
 
   rhea@1.0.24:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26656,6 +26851,24 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  send@0.19.0:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   send@1.2.0:
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
@@ -26683,6 +26896,15 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  serve-static@1.16.2:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
 
   serve-static@2.2.0:
     dependencies:
@@ -27986,6 +28208,8 @@ snapshots:
       is-typed-array: 1.1.13
       which-typed-array: 1.1.15
 
+  utils-merge@1.0.1: {}
+
   uuencode@0.0.4: {}
 
   uuid@10.0.0: {}
@@ -28166,6 +28390,8 @@ snapshots:
   vue-component-type-helpers@2.1.10: {}
 
   vue-component-type-helpers@2.2.10: {}
+
+  vue-component-type-helpers@3.0.8: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.8.2)):
     dependencies:


### PR DESCRIPTION
## Summary
- add a standalone `@n8n/voice-mailer` example that exposes an express backend for speech transcription via OpenAI Whisper and email delivery over SMTP
- build a minimal browser UI with a large recording button, transcription trigger, and live status feedback
- document setup requirements and provide environment configuration template for API and mail credentials

## Testing
- pnpm install --filter @n8n/voice-mailer...


------
https://chatgpt.com/codex/tasks/task_e_68d4f16eae148322bbddba48424df417